### PR TITLE
CVE from ghsa

### DIFF
--- a/src/main/java/businessObjects/GraphQlQueries.java
+++ b/src/main/java/businessObjects/GraphQlQueries.java
@@ -25,4 +25,5 @@ package businessObjects;
 
 public final class GraphQlQueries {
     public static final String GHSA_SECURITY_ADVISORY_QUERY = "query { securityAdvisory(ghsaId: \"%s\") { ghsaId summary cwes(first : 1) { nodes { cweId } } } }";
+    public static final String GHSA_WEB_PIQUE_SECURITY_ADVISORY_QUERY = "query { securityAdvisory(ghsaId: \"%s\") { ghsaId summary identifiers{type value} cwes(first : 1) { nodes { cweId } } } }";
 }

--- a/src/main/java/businessObjects/WebPiqueGHSARequest.java
+++ b/src/main/java/businessObjects/WebPiqueGHSARequest.java
@@ -1,0 +1,88 @@
+package businessObjects;
+
+import businessObjects.baseClasses.BaseRequest;
+import businessObjects.baseClasses.BaseResponse;
+import businessObjects.ghsa.WebPiqueSecurityAdvisory;
+import exceptions.ApiCallException;
+import handlers.JsonResponseHandler;
+import handlers.WebPiqueSecurityAdvisoryMarshaller;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+import static common.Constants.*;
+
+public class WebPiqueGHSARequest extends BaseRequest implements IRequest{
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebPiqueGHSARequest.class);
+    private final JsonResponseHandler handler;
+    private final String query;
+    private final WebPiqueSecurityAdvisoryMarshaller marshaller;
+
+    public WebPiqueGHSARequest(String httpMethod, String baseURI, Header[] headers, String query, WebPiqueSecurityAdvisoryMarshaller marshaller, JsonResponseHandler jsonResponseHandler) {
+        super(httpMethod, baseURI, headers);
+        this.query = query;
+        this.marshaller = marshaller;
+        this.handler = jsonResponseHandler;
+    }
+
+    @Override
+    public WebPiqueGHSAResponse executeRequest() throws ApiCallException {
+        return executeWebPiqueRequest();
+    }
+
+    public WebPiqueGHSAResponse executeWebPiqueRequest() throws ApiCallException {
+        return makeHttpCall(formatRequest(buildUri()));
+    }
+
+    private URI buildUri() {
+        try {
+            return new URIBuilder(baseUri).build();
+        } catch (URISyntaxException e) {
+            LOGGER.error(URI_BUILD_FAILURE_MESSAGE, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private WebPiqueGHSAResponse makeHttpCall(HttpPost request) throws ApiCallException {
+        try (CloseableHttpClient client = HttpClients.createDefault();
+             CloseableHttpResponse response = client.execute(request)) {
+
+            return processHttpResponse(response);
+
+        } catch ( IOException e) {
+            throw new ApiCallException(e);
+        }
+    }
+
+    private WebPiqueGHSAResponse processHttpResponse(HttpResponse response) throws IOException {
+        int status = response.getStatusLine().getStatusCode();
+        if (status >= 200 && status < 300) {
+            return new WebPiqueGHSAResponse(
+                    marshaller.unmarshalJson(handler.handleResponse(response)),
+                    status);
+        } else {
+            LOGGER.info(RESPONSE_STATUS_MESSAGE, status);
+            throw new IOException(REQUEST_EXECUTION_FAILURE_MESSAGE + response.getStatusLine());
+        }
+    }
+
+    private HttpPost formatRequest(URI uri) {
+        HttpPost request = new HttpPost(uri);
+        request.setHeaders(headers);
+        request.setEntity(new StringEntity(query, StandardCharsets.UTF_8));
+
+        return request;
+    }
+}

--- a/src/main/java/businessObjects/WebPiqueGHSARequest.java
+++ b/src/main/java/businessObjects/WebPiqueGHSARequest.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 import static common.Constants.*;
 
-public class WebPiqueGHSARequest extends BaseRequest implements IRequest{
+public final class WebPiqueGHSARequest extends BaseRequest implements IRequest{
     private static final Logger LOGGER = LoggerFactory.getLogger(WebPiqueGHSARequest.class);
     private final JsonResponseHandler handler;
     private final String query;

--- a/src/main/java/businessObjects/WebPiqueGHSAResponse.java
+++ b/src/main/java/businessObjects/WebPiqueGHSAResponse.java
@@ -1,0 +1,20 @@
+package businessObjects;
+
+import businessObjects.baseClasses.BaseResponse;
+import businessObjects.ghsa.WebPiqueSecurityAdvisory;
+import exceptions.ApiCallException;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebPiqueGHSAResponse extends BaseResponse {
+
+    private WebPiqueSecurityAdvisory entity;
+
+    public WebPiqueGHSAResponse(WebPiqueSecurityAdvisory entity, int status) throws ApiCallException {
+        this.entity = entity;
+        this.status = status;
+    }
+
+}

--- a/src/main/java/businessObjects/WebPiqueGHSAResponse.java
+++ b/src/main/java/businessObjects/WebPiqueGHSAResponse.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class WebPiqueGHSAResponse extends BaseResponse {
+public final class WebPiqueGHSAResponse extends BaseResponse {
 
     private WebPiqueSecurityAdvisory entity;
 

--- a/src/main/java/businessObjects/ghsa/WebPiqueSecurityAdvisory.java
+++ b/src/main/java/businessObjects/ghsa/WebPiqueSecurityAdvisory.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Getter
 @Setter
-public class WebPiqueSecurityAdvisory extends BaseEntity {
+public final class WebPiqueSecurityAdvisory extends BaseEntity {
     private String ghsaId;
     private String summary;
     private Cwes cwes;

--- a/src/main/java/businessObjects/ghsa/WebPiqueSecurityAdvisory.java
+++ b/src/main/java/businessObjects/ghsa/WebPiqueSecurityAdvisory.java
@@ -1,0 +1,25 @@
+package businessObjects.ghsa;
+
+import businessObjects.baseClasses.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Optional;
+
+@Getter
+@Setter
+public class WebPiqueSecurityAdvisory extends BaseEntity {
+    private String ghsaId;
+    private String summary;
+    private Cwes cwes;
+    private String cve;
+
+
+    /**
+     *
+     * @return Optional that will contain the CVE alias for the ghsaId if it exists in the GHSA Database
+     */
+    public Optional<String> getCve() {
+        return Optional.ofNullable(cve);
+    }
+}

--- a/src/main/java/handlers/WebPiqueSecurityAdvisoryMarshaller.java
+++ b/src/main/java/handlers/WebPiqueSecurityAdvisoryMarshaller.java
@@ -1,0 +1,80 @@
+package handlers;
+
+import businessObjects.ghsa.Cwes;
+import businessObjects.ghsa.Nodes;
+import businessObjects.ghsa.SecurityAdvisory;
+import businessObjects.ghsa.WebPiqueSecurityAdvisory;
+import com.google.gson.Gson;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WebPiqueSecurityAdvisoryMarshaller {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityAdvisoryMarshaller.class);
+
+    public WebPiqueSecurityAdvisory unmarshalJson(String json) {
+        WebPiqueSecurityAdvisory securityAdvisory = new WebPiqueSecurityAdvisory();
+        Cwes cwes = new Cwes();
+        try {
+            JSONObject jsonObject = new JSONObject(json);
+            JSONObject jsonResponse = jsonObject.optJSONObject("data").optJSONObject("securityAdvisory");
+            if (jsonResponse != null) {
+                securityAdvisory.setGhsaId(jsonResponse.optString("ghsaId"));
+                securityAdvisory.setSummary(jsonResponse.optString("summary"));
+                securityAdvisory.setCve(getCveFromJson(jsonResponse));
+                cwes.setNodes(getNodesFromJson(jsonResponse));
+                securityAdvisory.setCwes(cwes);
+            } else {
+                LOGGER.info("GHSA response was null");
+            }
+        } catch (JSONException e) {
+            LOGGER.error("Malformed Json", e);
+            throw new RuntimeException(e);
+        }
+
+        return securityAdvisory;
+    }
+
+    public String marshalJson(SecurityAdvisory advisory) {
+        return new Gson().toJson(advisory);
+    }
+
+    /**
+     * If a CVE ID exists for this GHSA ID it will be returned else
+     * this function will return null. This null value is handled by the SecurityAdvisory Object.
+     *
+     * @param jsonResponse
+     * @return String or null
+     */
+    private String getCveFromJson(JSONObject jsonResponse) {
+        JSONArray identifiers = jsonResponse.optJSONArray("identifiers");
+        for (int i = 1; i < identifiers.length(); i++) {
+            if (identifiers.optJSONObject(i).optString("type").equals("CVE")) {
+                return identifiers.optJSONObject(i).optString("value");
+            }
+        }
+        return null;
+    }
+
+    private List<Nodes> getNodesFromJson(JSONObject response) {
+        ArrayList<Nodes> nodes = new ArrayList<>();
+        try {
+            JSONArray jsonNodes = response.optJSONObject("cwes").optJSONArray("nodes");
+            for (int i = 0; i < jsonNodes.length(); i++) {
+                Nodes cweNode = new Nodes();
+                cweNode.setCweId(jsonNodes.optJSONObject(i).getString("cweId"));
+                nodes.add(cweNode);
+            }
+        } catch (JSONException e) {
+            LOGGER.error("Malformed Json", e);
+            throw new RuntimeException(e);
+        }
+        return nodes;
+
+    }
+}

--- a/src/main/java/presentation/PiqueData.java
+++ b/src/main/java/presentation/PiqueData.java
@@ -26,6 +26,7 @@ package presentation;
 import businessObjects.cve.Cve;
 import businessObjects.cve.Metrics;
 import businessObjects.ghsa.SecurityAdvisory;
+import businessObjects.ghsa.WebPiqueSecurityAdvisory;
 import exceptions.ApiCallException;
 import exceptions.DataAccessException;
 import service.*;
@@ -48,15 +49,18 @@ import java.util.Optional;
 public class PiqueData {
     protected final NvdApiService nvdApiService;
     protected final GhsaApiService ghsaApiService;
+    protected final WebPiqueGhsaApiService webPiqueGhsaApiService;
     protected final INvdMirrorService mirrorService;
     protected final CveResponseProcessor cveResponseProcessor;
 
-    public PiqueData(NvdApiService nvdApiService, GhsaApiService ghsaApiService, INvdMirrorService mirrorService, CveResponseProcessor cveResponseProcessor) {
+    public PiqueData(NvdApiService nvdApiService, GhsaApiService ghsaApiService, WebPiqueGhsaApiService webPiqueGhsaApiService, INvdMirrorService mirrorService, CveResponseProcessor cveResponseProcessor) {
         this.nvdApiService = nvdApiService;
         this.ghsaApiService = ghsaApiService;
+        this.webPiqueGhsaApiService = webPiqueGhsaApiService;
         this.mirrorService = mirrorService;
         this.cveResponseProcessor = cveResponseProcessor;
     }
+
 
     /**
      * Gets a cve from the specified database. (switching on dbContext) This does NOT call the NVD
@@ -112,8 +116,29 @@ public class PiqueData {
     }
 
     /**
+     * Calls the GitHub Security Advisory Database. This is currently optimized for Web Pique
+     * @param ghsaId the official GHSA ID of interest as published by GitHub
+     * @return Returns a WebPiqueSecurityAdvisory object optimized for use in the SBOM wrapper
+     * @throws ApiCallException
+*/
+    public WebPiqueSecurityAdvisory getWebPiqueGHSA(String ghsaId) throws ApiCallException{
+        return webPiqueGhsaApiService.handleGetEntity(ghsaId);
+    }
+
+
+    /**
+     *  Calls the GitHub Security Advisory Database. This is currently optimized for Web Pique.
+     *  This will return an Optional that will contain the CVE alias for the queried GHSA if it exists.
+     * @param ghsaId the official GHSA ID of interest as published by GitHub
+     * @return Returns an Optional that will contain the CVE alias of the GHSA if it exists in the GHSA database
+     * @throws ApiCallException
+     */
+    public Optional<String> getCveFromGhsa(String ghsaId) throws ApiCallException{
+        return webPiqueGhsaApiService.handleGetEntity(ghsaId).getCve();
+    }
+
+    /**
      * Calls GitHub's Security Advisory database and returns a formatted List of CWE names as Strings.
-     *
      * @param ghsaId
      * @return
      * @throws ApiCallException

--- a/src/main/java/presentation/PiqueDataFactory.java
+++ b/src/main/java/presentation/PiqueDataFactory.java
@@ -24,10 +24,7 @@
 package presentation;
 
 import com.google.gson.Gson;
-import handlers.IJsonSerializer;
-import handlers.JsonResponseHandler;
-import handlers.JsonSerializer;
-import handlers.SecurityAdvisoryMarshaller;
+import handlers.*;
 import persistence.IDataSource;
 import persistence.postgreSQL.Migration;
 import persistence.postgreSQL.PostgresConnectionManager;
@@ -42,6 +39,7 @@ public class PiqueDataFactory {
     private final IJsonSerializer jsonSerializer = new JsonSerializer(new Gson());
     private final GhsaApiService ghsaApiService = new GhsaApiService(new GhsaResponseProcessor(), new SecurityAdvisoryMarshaller(), jsonResponseHandler);
     private final CveResponseProcessor cveResponseProcessor = new CveResponseProcessor();
+    private final WebPiqueGhsaApiService webPiqueGhsaApiService = new WebPiqueGhsaApiService(new WebPiqueSecurityAdvisoryMarshaller(), jsonResponseHandler);
     private final IDataSource<Connection> pgDataSource;
 
     public PiqueDataFactory() {
@@ -56,6 +54,7 @@ public class PiqueDataFactory {
         return new PiqueData(
                 new NvdApiService(jsonResponseHandler, jsonSerializer),
                 ghsaApiService,
+                webPiqueGhsaApiService,
                 instantiatePgMirrorService(),
                 cveResponseProcessor);
     }

--- a/src/main/java/service/WebPiqueGhsaApiService.java
+++ b/src/main/java/service/WebPiqueGhsaApiService.java
@@ -1,0 +1,100 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Montana State University Software Engineering and Cybersecurity Laboratory
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package service;
+
+import businessObjects.*;
+import businessObjects.ghsa.Nodes;
+import businessObjects.ghsa.SecurityAdvisory;
+import businessObjects.ghsa.WebPiqueSecurityAdvisory;
+import common.Constants;
+import exceptions.ApiCallException;
+import handlers.JsonResponseHandler;
+import handlers.SecurityAdvisoryMarshaller;
+import handlers.WebPiqueSecurityAdvisoryMarshaller;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import persistence.HeaderBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WebPiqueGhsaApiService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebPiqueGhsaApiService.class);
+    private final WebPiqueSecurityAdvisoryMarshaller marshaller;
+    private final JsonResponseHandler responseHandler;
+
+    public WebPiqueGhsaApiService(WebPiqueSecurityAdvisoryMarshaller marshaller, JsonResponseHandler responseHandler) {
+        this.marshaller = marshaller;
+        this.responseHandler = responseHandler;
+    }
+
+    public WebPiqueSecurityAdvisory handleGetEntity(String ghsaId) throws ApiCallException {
+        String CONTENT_TYPE = "Content-Type";
+        String APP_JSON = "application/json";
+        String AUTHORIZATION = "Authorization";
+
+        WebPiqueGHSARequest ghsaRequest = new WebPiqueGHSARequest(
+                HTTPMethod.POST,
+                Constants.GHSA_URI,
+                new HeaderBuilder()
+                        .addHeader(CONTENT_TYPE, APP_JSON)
+                        .addHeader(AUTHORIZATION, String.format("Bearer %s", System.getenv("GITHUB_PAT")))
+                        .build(),
+                formatQueryBody(ghsaId),
+                marshaller,
+                responseHandler);
+        WebPiqueGHSAResponse webPiqueGHSAResponse = ghsaRequest.executeRequest();
+
+        int status = webPiqueGHSAResponse.getStatus();
+        if (status >= 200 && status < 300) {
+            return webPiqueGHSAResponse.getEntity();
+        } else {
+            throw new ApiCallException(status);
+        }
+    }
+
+    public List<String> handleGetCweIdsFromGhsa(String ghsaId) throws ApiCallException {
+        WebPiqueSecurityAdvisory webPiqueSecurityAdvisory = handleGetEntity(ghsaId);
+        List<String> cwes = new ArrayList<>();
+        for (Nodes node : webPiqueSecurityAdvisory.getCwes().getNodes()){
+            cwes.add(node.getCweId());
+        }
+        return cwes;
+    }
+
+    // TODO replace the following methods with dedicated GraphQL library
+    private String formatQueryBody(String ghsaId) {
+        JSONObject jsonBody = new JSONObject();
+        try {
+            jsonBody.put("query", GraphQlQueries.GHSA_WEB_PIQUE_SECURITY_ADVISORY_QUERY);
+            String query = jsonBody.toString();
+            return String.format(query, ghsaId);
+        } catch (JSONException e) {
+            LOGGER.error("Improper JSON formatting. Check query format. ", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/PiqueDataTests.java
+++ b/src/test/java/PiqueDataTests.java
@@ -146,6 +146,18 @@ public class PiqueDataTests {
 
     @Tag("api")
     @Test
+    public void testGetCveFromGhsa() throws ApiCallException {
+
+        //TODO: Figure out how find a GHSA that will never have a CVE alias
+
+        assertEquals(TestConstants.CVE_ID_A,
+                piqueData.getWebPiqueGHSA(TestConstants.GHSA_ID_A).getCve().orElse(null));
+        assertEquals(TestConstants.CVE_ID_B,
+                piqueData.getWebPiqueGHSA(TestConstants.GHSA_ID_B).getCve().orElse(null));
+    }
+
+    @Tag("api")
+    @Test
     public void testGetCweIdsFromGhsa() throws ApiCallException {
         assertEquals(
                 TestConstants.GHSA_CWE_A_ORACLE,

--- a/src/test/java/TestConstants.java
+++ b/src/test/java/TestConstants.java
@@ -28,7 +28,9 @@ public class TestConstants {
     public static final String BAD_FORMAT = "not-a-cve";
     public static final String CVE_B = "CVE-1999-1302";
     public static final String GHSA_ID_A = "GHSA-vh2m-22xx-q94f";
+    public static final String CVE_ID_A = "CVE-2024-32028";
     public static final String GHSA_ID_B = "GHSA-hx9v-6r9f-w677";
+    public static final String CVE_ID_B = "CVE-2024-41950";
 
 
     public static final String CVE_A_CWE_ORACLE = "NVD-CWE-Other";


### PR DESCRIPTION
Altered the GraphQL query to get alternate IDs for GHSA IDs. If the list of alt IDs contains a CVE ID, it is added to the SecurityAdvisory Object and is accessible to the user as an Optional. I have also included some tests. 